### PR TITLE
Added npm ignore file to reduce package size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,36 @@
+# This file should include also any files in .gitignore, if the build process is performed locally
+
+
+##############################
+# Adding .gitignore files 
+
+node_modules/
+.expo/
+npm-debug.*
+*.jks
+*.p8
+*.p12
+*.key
+*.mobileprovision
+*.orig.*
+web-build/
+
+# macOS
+.DS_Store
+.idea/
+##############################
+
+# Examples 
+examples/
+assets/
+.expo-shared/
+App.tsx
+
+# Build files
+.husky/
+app.config.ts
+.travis.yml
+.prettierrc
+.eslintignore
+.eslintrc.js
+babel.config.js

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-compare-slider",
   "main": "index.ts",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Compare slider for React Native. Compare any two components side by side.",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Resolves #9 (Not fully, but reduces package size).

npm-link doesn't work because react native doesn't support symbolic links. 
The are two alternatives, if we still want the seperation, outlined here:
https://stackoverflow.com/questions/44061155/react-native-npm-link-local-dependency-unable-to-resolve-module

1. Use watchman for synchronizing without symlinks
2. Using repack (the new version of Haul) to replace metro as the bundler